### PR TITLE
Fix loop assignment to selector

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -18,3 +20,10 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+
+      - name: vet
+        run: go vet ./...
+
+      - uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1.3"

--- a/noloopclosure.go
+++ b/noloopclosure.go
@@ -62,10 +62,10 @@ type issue struct {
 func getRangeStmtLoopVars(pass *analysis.Pass, stmt *ast.RangeStmt) []types.Object {
 	var loopVars []types.Object
 	if val := stmt.Value; val != nil {
-		loopVars = append(loopVars, pass.TypesInfo.ObjectOf((val.(*ast.Ident))))
+		loopVars = append(loopVars, pass.TypesInfo.ObjectOf(getIdent(val)))
 	}
 	if key := stmt.Key; key != nil {
-		loopVars = append(loopVars, pass.TypesInfo.ObjectOf((key.(*ast.Ident))))
+		loopVars = append(loopVars, pass.TypesInfo.ObjectOf(getIdent(key)))
 	}
 	return loopVars
 
@@ -79,10 +79,20 @@ func getForStmtLoopVars(pass *analysis.Pass, stmt *ast.ForStmt) []types.Object {
 
 	var loopVars []types.Object
 	for _, lhs := range assignStmt.Lhs {
-		loopVars = append(loopVars, pass.TypesInfo.ObjectOf(lhs.(*ast.Ident)))
+		loopVars = append(loopVars, pass.TypesInfo.ObjectOf(getIdent(lhs)))
 	}
 
 	return loopVars
+}
+
+func getIdent(expr ast.Expr) *ast.Ident {
+	switch ee := expr.(type) {
+	case *ast.Ident:
+		return ee
+	case *ast.SelectorExpr:
+		return ee.Sel
+	}
+	panic("lol")
 }
 
 func getIssues(pass *analysis.Pass, loopVarObjs []types.Object, body *ast.BlockStmt) []issue {

--- a/noloopclosure.go
+++ b/noloopclosure.go
@@ -1,6 +1,7 @@
 package noloopclosure
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
@@ -17,101 +18,137 @@ var Analyzer = &analysis.Analyzer{
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 }
 
-var errMsgFormat = "found reference to loop variable `%s`. Consider to duplicate variable `%s` before using it inside the function closure."
+var errMsgFormat = "found captured reference to loop variable inside a closure"
 
-func run(pass *analysis.Pass) (interface{}, error) {
-	inspector := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+type analyzerState struct {
+	pass *analysis.Pass
 
-	filter := []ast.Node{(*ast.ForStmt)(nil), (*ast.RangeStmt)(nil)}
-	inspector.Preorder(filter, func(n ast.Node) {
-		var loopVarObjs []types.Object
-		var body *ast.BlockStmt
-		switch nn := n.(type) {
-		case *ast.RangeStmt:
-			loopVarObjs = getRangeStmtLoopVars(pass, nn)
-			body = nn.Body
-		case *ast.ForStmt:
-			loopVarObjs = getForStmtLoopVars(pass, nn)
-			body = nn.Body
+	loopVars []types.Object
+	issues   map[string]token.Pos
+}
+
+func (state *analyzerState) processRangeStmt(stmt *ast.RangeStmt) {
+	if val := stmt.Value; val != nil {
+		state.markAsLoopVars(val)
+	}
+
+	if key := stmt.Key; key != nil {
+		state.markAsLoopVars(key)
+	}
+}
+
+func (state *analyzerState) processForStmt(stmt *ast.ForStmt) {
+	if stmt.Init != nil {
+		state.processForStmtClause(stmt.Init)
+	}
+
+	if stmt.Post != nil {
+		state.processForStmtClause(stmt.Post)
+	}
+}
+
+func (state *analyzerState) processForStmtClause(clause ast.Stmt) {
+	switch stmt := clause.(type) {
+	case *ast.AssignStmt:
+		for _, lhs := range stmt.Lhs {
+			state.markAsLoopVars(lhs)
 		}
+	case *ast.IncDecStmt:
+		state.markAsLoopVars(stmt.X)
+	}
+}
 
-		if loopVarObjs == nil {
+func (state *analyzerState) markAsLoopVars(expr ast.Expr) {
+	obj := state.pass.TypesInfo.ObjectOf(state.getIdent(expr))
+	if obj == nil {
+		return
+	}
+
+	for _, o := range state.loopVars {
+		if obj == o {
 			return
 		}
-
-		ast.Inspect(body, func(n ast.Node) bool {
-			if flit, ok := n.(*ast.FuncLit); ok {
-				issues := getIssues(pass, loopVarObjs, flit.Body)
-
-				for _, v := range issues {
-					pass.Reportf(v.pos, errMsgFormat, v.varName, v.varName)
-				}
-			}
-			return true
-		})
-	})
-
-	return nil, nil
-}
-
-type issue struct {
-	pos     token.Pos
-	varName string
-}
-
-func getRangeStmtLoopVars(pass *analysis.Pass, stmt *ast.RangeStmt) []types.Object {
-	var loopVars []types.Object
-	if val := stmt.Value; val != nil {
-		loopVars = append(loopVars, pass.TypesInfo.ObjectOf(getIdent(val)))
-	}
-	if key := stmt.Key; key != nil {
-		loopVars = append(loopVars, pass.TypesInfo.ObjectOf(getIdent(key)))
-	}
-	return loopVars
-
-}
-
-func getForStmtLoopVars(pass *analysis.Pass, stmt *ast.ForStmt) []types.Object {
-	assignStmt, ok := stmt.Init.(*ast.AssignStmt)
-	if !ok {
-		return nil
 	}
 
-	var loopVars []types.Object
-	for _, lhs := range assignStmt.Lhs {
-		loopVars = append(loopVars, pass.TypesInfo.ObjectOf(getIdent(lhs)))
-	}
-
-	return loopVars
+	state.loopVars = append(state.loopVars, obj)
 }
 
-func getIdent(expr ast.Expr) *ast.Ident {
+func (state *analyzerState) getIdent(expr ast.Expr) *ast.Ident {
 	switch ee := expr.(type) {
+	case *ast.ParenExpr:
+		return state.getIdent(ee.X)
 	case *ast.Ident:
 		return ee
 	case *ast.SelectorExpr:
 		return ee.Sel
+	case *ast.IndexExpr:
+		return state.getIdent(ee.X)
+	case *ast.StarExpr:
+		return state.getIdent(ee.X)
+	default:
+		//  Note: if you reach this state, please raise an issue, thanks!
+		return nil
 	}
-	panic("lol")
 }
 
-func getIssues(pass *analysis.Pass, loopVarObjs []types.Object, body *ast.BlockStmt) []issue {
-	var issues []issue
-
+func (state *analyzerState) processBody(body *ast.BlockStmt) {
 	ast.Inspect(body, func(n ast.Node) bool {
 		ident, ok := n.(*ast.Ident)
 		if !ok {
 			return true
 		}
 
-		for _, loopVarObj := range loopVarObjs {
-			if pass.TypesInfo.ObjectOf(ident) == loopVarObj {
-				issues = append(issues, issue{pos: ident.Pos(), varName: ident.Name})
+		for _, loopVarObj := range state.loopVars {
+			if state.pass.TypesInfo.ObjectOf(ident) == loopVarObj {
+				state.markAsIssue(ident.Pos())
 			}
 		}
 
 		return true
 	})
+}
 
-	return issues
+func (state *analyzerState) markAsIssue(pos token.Pos) {
+	if state.issues == nil {
+		state.issues = map[string]token.Pos{}
+	}
+
+	pp := state.pass.Fset.Position(pos)
+	state.issues[fmt.Sprintf("%s:%d", pp.Filename, pp.Line)] = pos
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspector := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	filter := []ast.Node{(*ast.ForStmt)(nil), (*ast.RangeStmt)(nil)}
+	inspector.Preorder(filter, func(n ast.Node) {
+		state := analyzerState{pass: pass}
+
+		var body *ast.BlockStmt
+		switch nn := n.(type) {
+		case *ast.RangeStmt:
+			state.processRangeStmt(nn)
+			body = nn.Body
+		case *ast.ForStmt:
+			state.processForStmt(nn)
+			body = nn.Body
+		}
+
+		if state.loopVars == nil {
+			return
+		}
+
+		ast.Inspect(body, func(n ast.Node) bool {
+			if flit, ok := n.(*ast.FuncLit); ok {
+				state.processBody(flit.Body)
+			}
+			return true
+		})
+
+		for _, v := range state.issues {
+			pass.Reportf(v, errMsgFormat)
+		}
+	})
+
+	return nil, nil
 }

--- a/testdata/src/fixtures/fixture.go
+++ b/testdata/src/fixtures/fixture.go
@@ -30,7 +30,14 @@ func ForLoop() {
 	x := struct{ A int }{}
 	for x.A = 0; x.A < 5; x.A++ {
 		_ = func() {
-			fmt.Println(x.A) // want "found reference to loop variable `x.a`. consider to duplicate variable `x.a` before using it inside the function closure."
+			fmt.Println(x.A) // want "found reference to loop variable `A`. Consider to duplicate variable `A` before using it inside the function closure."
+		}
+	}
+
+	y := []int{1, 2, 3}
+	for y[1] = 0; y[1] < 5; y[1]++ {
+		_ = func() {
+			fmt.Println(y[1])
 		}
 	}
 }
@@ -60,7 +67,8 @@ func RangeLoop() {
 	x := struct{ A string }{}
 	for x.A = range map[string]int{} {
 		_ = func() {
-			fmt.Println(x.A) // want "found reference to loop variable `x.a`. consider to duplicate variable `x.a` before using it inside the function closure."
+			fmt.Println(x.A) // want "found reference to loop variable `A`. Consider to duplicate variable `A` before using it inside the function closure."
 		}
 	}
+
 }

--- a/testdata/src/fixtures/fixture.go
+++ b/testdata/src/fixtures/fixture.go
@@ -1,43 +1,104 @@
 package fixtures
 
-import "fmt"
-
 func ForLoop() {
+	for {
+
+	}
+
+	for false {
+		// noop
+	}
+
+	for i := 0; ; i++ {
+		_ = func() {
+			_ = i // want `found captured reference to loop variable inside a closure`
+		}
+	}
+
+	for i := 0; ; {
+		_ = i
+	}
+
 	for i := 0; i < 5; i++ {
 		_ = i
 	}
 
-	for false {
+	var i int
+	for i < 5 {
+		// Note: we ignore the condition clause to reduce false positive.
+		// Because it's hard to check which variable inside the condition that will be mutated.
+		_ = func() {
+			_ = i
+		}
 	}
 
 	for i := 0; i < 5; i++ {
 		_ = func() {
-			fmt.Println(i) // want "found reference to loop variable `i`. Consider to duplicate variable `i` before using it inside the function closure."
+			_ = i // want `found captured reference to loop variable inside a closure`
 		}
 	}
 
 	k := 5
-	for i, j := 0, 0; i < j; i++ {
+	for i, j := 0, 0; i < j; i, k = i+1, k+1 {
 		_ = func() {
-			fmt.Println(k)
+			// Not okay since it's listed in the PostInit.
+			_ = k // want "found captured reference to loop variable inside a closure"
 		}
 
 		_ = func() {
-			fmt.Println(i, j) // want "found reference to loop variable `i`. Consider to duplicate variable `i` before using it inside the function closure." "found reference to loop variable `j`. Consider to duplicate variable `j` before using it inside the function closure."
+			_ = i // want "found captured reference to loop variable inside a closure"
+
+			// Not okay, even if it's not part of the PostInit, as it's very likely that dev will mutate it somehow
+			// inside the for loop.
+			_ = j // want "found captured reference to loop variable inside a closure"
 		}
 	}
 
-	x := struct{ A int }{}
+	// Can handle ast.SelectorExpr properly.
+	x := struct {
+		A int
+		B int
+	}{}
 	for x.A = 0; x.A < 5; x.A++ {
 		_ = func() {
-			fmt.Println(x.A) // want "found reference to loop variable `A`. Consider to duplicate variable `A` before using it inside the function closure."
+			_ = x.A // want "found captured reference to loop variable inside a closure"
+			_ = x.B
 		}
 	}
 
-	y := []int{1, 2, 3}
-	for y[1] = 0; y[1] < 5; y[1]++ {
+	// Can handle ast.ParenExpr properly.
+	for (k) = 0; k < 5; k++ {
 		_ = func() {
-			fmt.Println(y[1])
+			_ = k // want "found captured reference to loop variable inside a closure"
+		}
+	}
+
+	// Can handle ast.StarExpr properly.
+	var p *int = new(int)
+	for *p = 0; *p < 5; (*p)++ {
+		_ = func() {
+			_ = *p // want "found captured reference to loop variable inside a closure"
+			_ = p  // want "found captured reference to loop variable inside a closure"
+		}
+	}
+
+	// Can handle ast.IndexExpr properly.
+	arrayOfInt := []int{1, 2, 3}
+	for arrayOfInt[1] = 0; arrayOfInt[1] < 5; arrayOfInt[1]++ {
+		_ = func() {
+			// Note: we will disallow any captured reference to the array, not just arrayOfInt[1]
+			// because we cant accurately know which index that is being mutated in compile time.
+			//
+			// Generally it's a good practice to not do this anyway hence we raise it as an issue.
+			_ = arrayOfInt[1] // want "found captured reference to loop variable inside a closure"
+		}
+	}
+
+	mapOfInt := map[int]int{1: 1}
+	for mapOfInt[1] = 0; mapOfInt[1] < 5; mapOfInt[1]++ {
+		_ = func() {
+			// Note: disallow any captured reference to the map.
+			_ = mapOfInt[1] // want "found captured reference to loop variable inside a closure"
 		}
 	}
 }
@@ -45,19 +106,20 @@ func ForLoop() {
 func RangeLoop() {
 	for k, v := range map[string]int{} {
 		_ = func() {
-			fmt.Println(k, v) // want "found reference to loop variable `k`. Consider to duplicate variable `k` before using it inside the function closure." "found reference to loop variable `v`. Consider to duplicate variable `v` before using it inside the function closure."
+			_ = k // want "found captured reference to loop variable inside a closure"
+			_ = v // want "found captured reference to loop variable inside a closure"
 		}
 	}
 
 	for _, v := range map[string]int{} {
 		_ = func() {
-			fmt.Println(v) // want "found reference to loop variable `v`. Consider to duplicate variable `v` before using it inside the function closure."
+			_ = v // want "found captured reference to loop variable inside a closure"
 		}
 	}
 
 	for k := range map[string]int{} {
 		_ = func() {
-			fmt.Println(k) // want "found reference to loop variable `k`. Consider to duplicate variable `k` before using it inside the function closure."
+			_ = k // want "found captured reference to loop variable inside a closure"
 		}
 	}
 
@@ -67,8 +129,7 @@ func RangeLoop() {
 	x := struct{ A string }{}
 	for x.A = range map[string]int{} {
 		_ = func() {
-			fmt.Println(x.A) // want "found reference to loop variable `A`. Consider to duplicate variable `A` before using it inside the function closure."
+			_ = x.A // want "found captured reference to loop variable inside a closure"
 		}
 	}
-
 }

--- a/testdata/src/fixtures/fixture.go
+++ b/testdata/src/fixtures/fixture.go
@@ -26,6 +26,13 @@ func ForLoop() {
 			fmt.Println(i, j) // want "found reference to loop variable `i`. Consider to duplicate variable `i` before using it inside the function closure." "found reference to loop variable `j`. Consider to duplicate variable `j` before using it inside the function closure."
 		}
 	}
+
+	x := struct{ A int }{}
+	for x.A = 0; x.A < 5; x.A++ {
+		_ = func() {
+			fmt.Println(x.A) // want "found reference to loop variable `x.a`. consider to duplicate variable `x.a` before using it inside the function closure."
+		}
+	}
 }
 
 func RangeLoop() {
@@ -48,5 +55,12 @@ func RangeLoop() {
 	}
 
 	for range map[string]int{} {
+	}
+
+	x := struct{ A string }{}
+	for x.A = range map[string]int{} {
+		_ = func() {
+			fmt.Println(x.A) // want "found reference to loop variable `x.a`. consider to duplicate variable `x.a` before using it inside the function closure."
+		}
 	}
 }

--- a/testdata/src/fixtures/fixture.go
+++ b/testdata/src/fixtures/fixture.go
@@ -38,6 +38,20 @@ func ForLoop() {
 		}
 	}
 
+	for i := 0; i < 5; i++ {
+		for j := 0; j < 5; j++ {
+			_ = func() {
+				_ = i // want `found captured reference to loop variable inside a closure`
+				_ = j // want `found captured reference to loop variable inside a closure`
+			}
+		}
+
+		var j int
+		_ = func() {
+			_ = j
+		}
+	}
+
 	k := 5
 	for i, j := 0, 0; i < j; i, k = i+1, k+1 {
 		_ = func() {


### PR DESCRIPTION
Resolves #2 

1. Cover more expression types.
2. Linter should not panic when it faces unhandled cases.
3. Exclude test files by default.
4. Add linter into github actions.